### PR TITLE
Fix: ワークフローの修正

### DIFF
--- a/.github/workflows/deploy_to_flyio.yml
+++ b/.github/workflows/deploy_to_flyio.yml
@@ -21,7 +21,7 @@ jobs:
           ruby-version: "3.1.2"
 
       - name: Docker build
-        working-directory: ./api
+        working-directory: ./gamearchive_backend/api
         run: |
           docker build -t $APP_NAME -f Dockerfile.prod .
 
@@ -33,12 +33,8 @@ jobs:
       - name: Fly Login
         run: flyctl auth token $FLY_API_TOKEN
 
-      # The following step is only needed for the first-time deployment
-      # - name: Create Fly.io App
-      #   run: flyctl apps create $APP_NAME
-
       - name: Deploy to Fly
-        run: flyctl deploy --app $APP_NAME
+        run: flyctl deploy --app $APP_NAME --working-dir ./gamearchive_backend/api
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
# 概要
Dockerfileが見つからないエラーが出たので修正
```
working-directory: ./gamearchive_backend/api
        run: |
          docker build -t $APP_NAME -f Dockerfile.prod .
```
デプロイするフォルダをapiに指定
```
- name: Deploy to Fly
        # gamearchive_backend/api を指定してデプロイを行います
        run: flyctl deploy --app $APP_NAME --working-dir ./gamearchive_backend/api
```