### PR TITLE
Fix: ワークフローにmigrateに関する記述を削除。代わりにentrypoint.shに記述

### DIFF
--- a/.github/workflows/deploy_to_flyio.yml
+++ b/.github/workflows/deploy_to_flyio.yml
@@ -38,9 +38,6 @@ jobs:
         working-directory: ./api
         run: flyctl deploy --app $APP_NAME
 
-      - name: Database Migration
-        run: flyctl run --app $APP_NAME 'rails db:migrate'
-
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
         if: always()

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -4,5 +4,9 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /var/www/tmp/pids/server.pid
 
+# Run database migrations
+echo "Running database migrations..."
+rails db:migrate
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
# 概要
flyctlではrunコマンドが使用できず、migrateする手段が見つからなかったため、entrypoint.shにmigrateコマンドに関する記述を追加した。
```
#!/bin/bash
set -e

# Remove a potentially pre-existing server.pid for Rails.
rm -f /var/www/tmp/pids/server.pid

# Run database migrations
echo "Running database migrations..."
rails db:migrate

# Then exec the container's main process (what's set as CMD in the Dockerfile).
exec "$@"
```