### PR TITLE
Remove: migrationに関する記述を削除

### DIFF
--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -4,9 +4,5 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /var/www/tmp/pids/server.pid
 
-# Run database migrations
-echo "Running database migrations..."
-rails db:migrate
-
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
# 概要
entrypoint.shでmigrationに関する記述を削除。
どうやらfly deploy時にrails db:migrateのコマンドなどを自動で行ってくれるらしい。

https://community.fly.io/t/rails-and-fly-io-bin-rails-db-migrate-vs-fly-deploy/8863