### PR TITLE
Fix: 本番環境でもrails db:migrateするようにworkflowを修正

### DIFF
--- a/.github/workflows/deploy_to_flyio.yml
+++ b/.github/workflows/deploy_to_flyio.yml
@@ -38,6 +38,11 @@ jobs:
         working-directory: ./api
         run: flyctl deploy --app $APP_NAME
 
+      - name: Database Migration
+        working-directory: ./api
+        run: |
+          docker run $APP_NAME bundle exec rails db:migrate
+
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
         if: always()


### PR DESCRIPTION
# 概要
本番環境にて以下のエラーが出たので
[![Image from Gyazo](https://i.gyazo.com/cda684fd468795595dded1c81749d60c.png)](https://gyazo.com/cda684fd468795595dded1c81749d60c)
ワークフローにrails db:migrateするよう促してみる。自動化を目指す
結果的には
#13 でいっていたことは間違いだった。