### PR TITLE
refactor: フロントURLをflyの環境変数側にsetする

### DIFF
--- a/api/app/controllers/api/v1/base_controller.rb
+++ b/api/app/controllers/api/v1/base_controller.rb
@@ -14,9 +14,6 @@ class Api::V1::BaseController < ApplicationController
       else
         user_result = User.find_or_create_user(result)
         @_current_user = user_result[:user]
-        if user_result[:is_new]
-          @_current_user.update(visibility: "private")
-        end
       end
     end
   end

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV["API_DOMAIN"] || "gamearchiveapp.com"
+    origins ENV["API_DOMAIN"] || ""
 
     resource '*',
       headers: :any,

--- a/api/fly.toml
+++ b/api/fly.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for gamearchive-backend on 2023-06-17T15:38:42+09:00
+# fly.toml app configuration file generated for gamearchive-backend on 2023-07-23T10:07:25+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #


### PR DESCRIPTION
# 概要
以下のことを行なった。
- firebase認証のidとapidomainの環境変数をfly.ioにセット
- 返答の高速化を図るためfly.ioのメモリーの上限を1GBに増やし、サーバーのスリープ状態を解除。

# Issue
Close #27 
Close #24 