### PR TITLE
reactor: 検索ルーティングをpostからgetメソッドに変更+検索アクションのapi処理部分を切り分ける。

### DIFF
--- a/api/app/controllers/api/v1/hello_controller.rb
+++ b/api/app/controllers/api/v1/hello_controller.rb
@@ -1,5 +1,0 @@
-class Api::V1::HelloController < ApplicationController
-  def index
-    render json: "Hello"
-  end
-end

--- a/api/app/controllers/api/v1/search_controller.rb
+++ b/api/app/controllers/api/v1/search_controller.rb
@@ -1,40 +1,14 @@
+# app/controllers/api/v1/search_controller.rb
 class Api::V1::SearchController < ApplicationController
   def search
-    conn = Faraday.new(url: 'https://api.igdb.com/v4/games') do |f|
-      f.request :url_encoded
-      f.response :json, content_type: /\bjson$/
-      f.adapter Faraday.default_adapter
-    end
+    search_terms = params[:search]
+    service = GameSearchService.new(search_terms)
+    result = service.call
 
-    search_terms = params[:search].split.map { |term| ERB::Util.url_encode(term) }.join(" ")
-
-    response = conn.post do |req|
-      req.headers['Client-ID'] = ENV['IGDB_CLIENT_ID']
-      req.headers['Authorization'] = ENV['IGDB_AUTHORIZATION']
-      req.headers['Accept-Language'] = 'ja'
-      req.body = "fields id, name, cover.url, genres.name, platforms.name, url, rating; limit 150; search \"#{search_terms}\";"
-    end
-
-    if response.success?
-      raw_games = response.body
-
-      games = raw_games.map do |game|
-        cover_url = game.dig('cover', 'url')
-        cover_big_url = cover_url ? "https://images.igdb.com/igdb/image/upload/t_cover_big/#{cover_url.split('/').last}" : nil
-        rating = game.dig('rating')
-        rounded_rating = rating ? rating.floor : nil
-        {
-          title: game['name'],
-          cover: cover_big_url,
-          rating: rounded_rating,
-          url: game['url'],
-          genres: (game['genres'] || []).map { |genre| genre['name'] },
-          platforms: (game['platforms'] || []).map { |platform| platform['name'] }
-        }
-      end
-      render json: games
+    if result[:error]
+      render json: { error: result[:error] }, status: :internal_server_error
     else
-      render json: { error: 'Error retrieving games' }, status: :internal_server_error
+      render json: result
     end
   end
 end

--- a/api/app/services/game_search_service.rb
+++ b/api/app/services/game_search_service.rb
@@ -1,0 +1,49 @@
+# app/services/game_search_service.rb
+class GameSearchService
+  def initialize(search_terms)
+    @search_terms = search_terms
+  end
+
+  def call
+    conn = Faraday.new(url: 'https://api.igdb.com/v4/games') do |f|
+      f.request :url_encoded
+      f.response :json, content_type: /\bjson$/
+      f.adapter Faraday.default_adapter
+    end
+
+    encoded_terms = @search_terms.split.map { |term| ERB::Util.url_encode(term) }.join(" ")
+
+    response = conn.post do |req|
+      req.headers['Client-ID'] = ENV['IGDB_CLIENT_ID']
+      req.headers['Authorization'] = ENV['IGDB_AUTHORIZATION']
+      req.headers['Accept-Language'] = 'ja'
+      req.body = "fields id, name, cover.url, genres.name, platforms.name, url, rating; limit 150; search \"#{encoded_terms}\";"
+    end
+
+    if response.success?
+      raw_games = response.body
+      transform_to_game_objects(raw_games)
+    else
+      { error: 'Error retrieving games' }
+    end
+  end
+
+  private
+
+  def transform_to_game_objects(raw_games)
+    raw_games.map do |game|
+      cover_url = game.dig('cover', 'url')
+      cover_big_url = cover_url ? "https://images.igdb.com/igdb/image/upload/t_cover_big/#{cover_url.split('/').last}" : nil
+      rating = game.dig('rating')
+      rounded_rating = rating ? rating.floor : nil
+      {
+        title: game['name'],
+        cover: cover_big_url,
+        rating: rounded_rating,
+        url: game['url'],
+        genres: (game['genres'] || []).map { |genre| genre['name'] },
+        platforms: (game['platforms'] || []).map { |platform| platform['name'] }
+      }
+    end
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,11 +1,10 @@
 Rails.application.routes.draw do
   namespace :api, format: "json" do
     namespace :v1 do
-      resources :hello, only: %w[index]
       resource :authentication, only: %w[create]
       resource :image, only: %w[create show]
       resource :profile, only: %w[show update]
-      post '/search', to: 'search#search'
+      get '/search', to: 'search#search'
       resources :games, only: %w[index create destroy] do
         collection do
           get 'favorites', to: 'games#favorites'


### PR DESCRIPTION
# 概要
上記の通り
[868103b](https://github.com/teruteru214/gamearchive_backend/pull/57/commits/868103ba269423d7d416c39671124e65192c17fa)はpostよりgetの方が可読性が上がるから。
[a59763f](https://github.com/teruteru214/gamearchive_backend/pull/57/commits/a59763f67ecc1221d19fd76c50a2cb6bca4e13dc)こちらも同様
# issue
Close #56 
Close #55 
Close #54 