### PR TITLE
Feat: line_settingテーブルの詳細をフロントに送る。

### DIFF
--- a/api/app/controllers/api/v1/line_settings_controller.rb
+++ b/api/app/controllers/api/v1/line_settings_controller.rb
@@ -23,7 +23,14 @@ class Api::V1::LineSettingsController < Api::V1::BaseController
 
 
   def show
-    line_setting = current_user.line_setting
+    user = User.find_by(uid: params[:uid])
+
+    unless user
+      render json: { error: 'User not found' }, status: :not_found
+      return
+    end
+
+    line_setting = user.line_setting
 
     if line_setting
       render json: LineSettingSerializer.new(line_setting).serializable_hash.to_json, status: :ok
@@ -35,6 +42,6 @@ class Api::V1::LineSettingsController < Api::V1::BaseController
   private
 
   def line_setting_params
-    params.require(:line_setting).permit(:line_user_id, :line_notification, :stacked_notification_interval, :favorite_notification_interval)
+    params.require(:line_setting).permit(:line_notification, :stacked_notification_interval, :favorite_notification_interval)
   end
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :game_statuses, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :favorited_games, through: :favorites, source: :game
-  has_one :line_settings, dependent: :destroy
+  has_one :line_setting, dependent: :destroy
 
   validates :nickname,    presence: true, length: { maximum: 40 }
   validates :uid,         presence:true, uniqueness: true

--- a/api/app/serializers/line_setting_serializer.rb
+++ b/api/app/serializers/line_setting_serializer.rb
@@ -1,4 +1,4 @@
 class LineSettingSerializer
   include JSONAPI::Serializer
-  attributes :line_user_id, :line_notification, :stacked_notification_interval, :favorite_notification_interval
+  attributes :id, :line_notification, :stacked_notification_interval, :favorite_notification_interval
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
       end
       resources :game_statuses, only: %w[update]
       resources :favorites, only: %w[create destroy]
-      resources :line_settings, only: %w[create show]
+      resource :line_settings, only: %w[create update]
+      get '/line_setting', to: 'line_settings#show'
     end
   end
 end


### PR DESCRIPTION
# 概要
フロント側で詳細画面のデータを反映できるように
