### PR TITLE
Remove: favorite_notification_intervalとそれに関するコードの削除

### DIFF
--- a/api/app/controllers/api/v1/line_settings_controller.rb
+++ b/api/app/controllers/api/v1/line_settings_controller.rb
@@ -57,6 +57,6 @@ class Api::V1::LineSettingsController < Api::V1::BaseController
   private
 
   def line_setting_params
-    params.require(:line_setting).permit(:line_notification, :stacked_notification_interval, :favorite_notification_interval)
+    params.require(:line_setting).permit(:line_notification, :stacked_notification_interval)
   end
 end

--- a/api/app/models/line_setting.rb
+++ b/api/app/models/line_setting.rb
@@ -2,7 +2,5 @@ class LineSetting < ApplicationRecord
   belongs_to :user
 
   validates :line_user_id, presence: true, uniqueness: true
-  validates :stacked_notification_interval, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 60 }
-  validates :favorite_notification_interval, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 60 }
-  validates :line_notification, inclusion: { in: [true, false] }
+  validates :stacked_notification_interval, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 60 }
 end

--- a/api/app/serializers/line_setting_serializer.rb
+++ b/api/app/serializers/line_setting_serializer.rb
@@ -1,4 +1,4 @@
 class LineSettingSerializer
   include JSONAPI::Serializer
-  attributes :id, :line_notification, :stacked_notification_interval, :favorite_notification_interval
+  attributes :id, :line_notification, :stacked_notification_interval
 end

--- a/api/db/migrate/20231002093952_remove_favorite_notification_interval_from_line_settings.rb
+++ b/api/db/migrate/20231002093952_remove_favorite_notification_interval_from_line_settings.rb
@@ -1,0 +1,5 @@
+class RemoveFavoriteNotificationIntervalFromLineSettings < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :line_settings, :favorite_notification_interval, :integer
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_18_084028) do
+ActiveRecord::Schema.define(version: 2023_10_02_093952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 2023_09_18_084028) do
     t.string "line_user_id", null: false
     t.boolean "line_notification", default: false
     t.integer "stacked_notification_interval", default: 30
-    t.integer "favorite_notification_interval", default: 30
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["line_user_id"], name: "index_line_settings_on_line_user_id", unique: true


### PR DESCRIPTION
# 概要
lineチャンネルからお気に入りのゲームをpush通知できるようになったので不要になった