### PR TITLE
Fix: line上でハイライトゲームが送信されないバグを修正。

### DIFF
--- a/api/app/controllers/api/v1/line_messages_controller.rb
+++ b/api/app/controllers/api/v1/line_messages_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::LineMessagesController < Api::V1::BaseController
 
   def handle_text_message(event)
     if event.message["text"] == "他ユーザーのお気に入りゲームを教えて"
-      user = User.where(visibility: "public").order("RANDOM()").first
+      user = User.joins(:favorites).where(visibility: "public").distinct.order("RANDOM()").first
       game = user.favorited_games.order("RANDOM()").first if user
 
       if user && game


### PR DESCRIPTION
# 概要
公開ユーザーの中でお気に入りのゲームを持っていない人がいると起きるバグを発見。
コード上で公開ユーザーをランダムに選ぶ際に、お気に入りのゲームを持っていない人は選ばないようにコードに追加