### PR TITLE
Fix: cronを起動するコマンドの記述漏れがあったので修正

### DIFF
--- a/api/Dockerfile.prod
+++ b/api/Dockerfile.prod
@@ -32,4 +32,4 @@ RUN chmod +x /start.sh
 EXPOSE 3000
 
 # コマンドの実行
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["/start.sh"]

--- a/api/start.sh
+++ b/api/start.sh
@@ -5,7 +5,7 @@ service cron start
 
 # `whenever` gemの設定を読み込み、cronにジョブを設定
 # (必要であれば、以下のコマンドを追加します)
-# bundle exec whenever --update-crontab
+bundle exec whenever --update-crontab
 
 # Railsサーバーを起動
 bundle exec rails s -p 3000 -b '0.0.0.0'


### PR DESCRIPTION
# 概要
cronが本番環境で動作しておらず通知が届かず、起動コマンドの記入漏れがあったのでDockerfile.prodを修正